### PR TITLE
URL encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 .DS_Store
+**.swp
+**.swo

--- a/lib/urlSerializer.js
+++ b/lib/urlSerializer.js
@@ -1,0 +1,41 @@
+var qs = require('querystring')
+
+module.exports = {
+  loadUrlConfig: loadUrlConfig,
+  saveUrlConfig: saveUrlConfig,
+};
+
+window.addEventListener('popstate', statePopped)
+
+function loadUrlConfig () {
+  var query = getUrlHalves()[1];
+  if (!query) return
+  query = qs.parse(query)
+  if (query.kit) {
+    var val
+    try {
+      val = JSON.parse(query.kit)
+    } catch (e) {}
+    return val;
+  }
+}
+
+function saveUrlConfig (config) {
+  var string = JSON.stringify(config)
+  var urlEncoded = encodeURIComponent(string)
+  var mainUrl = getUrlHalves()[0]
+
+  var newQueryString = '?kit=' + urlEncoded
+  history.pushState(config, 'web mpd', mainUrl + newQueryString);
+}
+
+// Returns the current URL split between main URL and queryString
+function getUrlHalves(){
+  var url = window.location.href
+  return url.split('?') 
+}
+
+// Called when user presses back, receives config object.
+function statePopped (ev) {
+//  debugger;
+}

--- a/lib/urlSerializer.js
+++ b/lib/urlSerializer.js
@@ -1,9 +1,15 @@
 var qs = require('querystring')
 
-module.exports = {
+var urlSerializer = {
   loadUrlConfig: loadUrlConfig,
   saveUrlConfig: saveUrlConfig,
+
+  // A callback function used
+  // to update the samples in memory.
+  stateChanged: null,
 };
+
+module.exports = urlSerializer;
 
 window.addEventListener('popstate', statePopped)
 
@@ -37,5 +43,7 @@ function getUrlHalves(){
 
 // Called when user presses back, receives config object.
 function statePopped (ev) {
-//  debugger;
+  if ( urlSerializer.stateChanged ){
+    urlSerializer.stateChanged(ev.state);
+  }
 }

--- a/style.css
+++ b/style.css
@@ -17,6 +17,10 @@ div#loading-screen{
   opacity:1.0;
   background-color:rgba(238,238,238,0.8);
 }
+div#loading-screen.hidden{
+  display:none;
+}
+
 div.column{
   flex:1 0 auto;
   -webkit-flex:1 0 auto;


### PR DESCRIPTION
The current kit is now preserved in the current URL, and visiting a `web-mpd` URL will restore the kit it was copied from.

Forward/back buttons in the browsers work.

Loading indication appears during forward/backward load times.
